### PR TITLE
Generate & publish sources jar for pax-logging-api.

### DIFF
--- a/pax-logging-api/pom.xml
+++ b/pax-logging-api/pom.xml
@@ -52,6 +52,19 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>attach-sources</id>
+                    <phase>process-classes</phase>
+                    <goals>
+                        <goal>jar</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Currently, sources.jar is generated only for the pax-logging-service module. This will generate sources.jar file for the pax-logging-api module as well.
