### PR TITLE
Fixed a shutdown problem with AsyncAppender in non-blocking mode

### DIFF
--- a/pax-logging-service/src/main/java/org/apache/log4j/AsyncAppender.java
+++ b/pax-logging-service/src/main/java/org/apache/log4j/AsyncAppender.java
@@ -513,6 +513,10 @@ public class AsyncAppender extends AppenderSkeleton
               isActive = !closed;
             }
 
+            if (closed && !blocking) {
+              break;
+            }
+
             if (bufferSize > 0) {
               events = new LoggingEvent[bufferSize + discardMap.size()];
               buffer.toArray(events);


### PR DESCRIPTION
Hi,

I used an AsyncAppender in a Karaf pax-logging environment in non-blocking mode. As long as the AsyncAppender was active in non-blocking mode, the Karaf could not shutdown with CTRL+D, instead you had to shutdown with CTRL+C. 

In some investigation, I found out, that the Dispatcher thread was the problem, since there seems to be a deadlock situation in the OSGi shutdown procedure when using an AsyncAppender in non-blocking mode. However, with this patch the problem does not occur any more, but it has the downfall, that some messages are potentially lost in this way.

I hope someone gives me some oppinion on this change :-)

Kind regards,
Felix
