### PR TITLE
Guard against NPE in PaxLoggerImpl.getLogLevel()

### DIFF
--- a/pax-logging-api/src/test/java/org/apache/log4j/CategoryTest.java
+++ b/pax-logging-api/src/test/java/org/apache/log4j/CategoryTest.java
@@ -154,6 +154,27 @@ public class CategoryTest extends TestCase
         testLog( Priority.DEBUG, "debug" );
     }
 
+    public void testGetEffectiveLevel()
+    {
+        final Mock mockDelegate = new Mock( PaxLogger.class );
+        mockDelegate.expects( new InvokeOnceMatcher() ).method( "getLogLevel" ).withAnyArguments().will( new ReturnStub( new Integer( -1 ) ) );
+        mockDelegate.expects( new InvokeOnceMatcher() ).method( "getLogLevel" ).withAnyArguments().will( new ReturnStub( new Integer( PaxLogger.LEVEL_ERROR ) ) );
+        mockDelegate.expects( new InvokeOnceMatcher() ).method( "getLogLevel" ).withAnyArguments().will( new ReturnStub( new Integer( PaxLogger.LEVEL_WARNING ) ) );
+        mockDelegate.expects( new InvokeOnceMatcher() ).method( "getLogLevel" ).withAnyArguments().will( new ReturnStub( new Integer( PaxLogger.LEVEL_INFO ) ) );
+        mockDelegate.expects( new InvokeOnceMatcher() ).method( "getLogLevel" ).withAnyArguments().will( new ReturnStub( new Integer( PaxLogger.LEVEL_DEBUG ) ) );
+        mockDelegate.expects( new InvokeOnceMatcher() ).method( "getLogLevel" ).withAnyArguments().will( new ReturnStub( new Integer( PaxLogger.LEVEL_TRACE ) ) );
+
+        final Category category = new SimpleCategory( (PaxLogger) mockDelegate.proxy() );
+        assertEquals( Level.TRACE , category.getEffectiveLevel() );
+        assertEquals( Level.DEBUG , category.getEffectiveLevel() );
+        assertEquals( Level.INFO , category.getEffectiveLevel() );
+        assertEquals( Level.WARN , category.getEffectiveLevel() );
+        assertEquals( Level.ERROR , category.getEffectiveLevel() );
+        assertEquals( null , category.getEffectiveLevel() );
+
+        mockDelegate.verify();
+    }
+
 	// Helpers
 
 	private void testIsEnabledFor( final Priority priority, final String method )

--- a/pax-logging-service/src/main/java/org/ops4j/pax/logging/service/internal/PaxLoggerImpl.java
+++ b/pax-logging-service/src/main/java/org/ops4j/pax/logging/service/internal/PaxLoggerImpl.java
@@ -300,7 +300,26 @@ public class PaxLoggerImpl
 
     public int getLogLevel()
     {
-        return m_delegate.getLevel().toInt();
+
+        Level level = m_delegate.getEffectiveLevel();
+
+        if ( level == null )
+            return LEVEL_ERROR;
+
+        if ( Level.TRACE.isGreaterOrEqual( level ) )
+            return LEVEL_TRACE;
+
+        if ( Level.DEBUG.isGreaterOrEqual( level ) )
+            return LEVEL_DEBUG;
+
+        if ( Level.INFO.isGreaterOrEqual( level ) )
+            return LEVEL_INFO;
+
+        if ( Level.WARN.isGreaterOrEqual( level ) )
+            return LEVEL_WARNING;
+
+        return LEVEL_ERROR;
+
     }
 
     public String getName()

--- a/pax-logging-service/src/test/java/org/ops4j/pax/logging/service/internal/PaxLoggerImplTest.java
+++ b/pax-logging-service/src/test/java/org/ops4j/pax/logging/service/internal/PaxLoggerImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed  under the  Apache License,  Version 2.0  (the "License");
+ * you may not use  this file  except in  compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed  under the  License is distributed on an "AS IS" BASIS,
+ * WITHOUT  WARRANTIES OR CONDITIONS  OF ANY KIND, either  express  or
+ * implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ops4j.pax.logging.service.internal;
+
+import java.lang.reflect.Constructor;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.ops4j.pax.logging.PaxLogger;
+
+import junit.framework.TestCase;
+
+public class PaxLoggerImplTest extends TestCase {
+
+    public void testGetEffectiveLevel() throws Exception
+    {
+        Constructor<Logger> c = Logger.class.getDeclaredConstructor( new Class[] { String.class } );
+        c.setAccessible( true );
+
+        Logger logger = c.newInstance( new Object[] { "test" } );
+        PaxLoggerImpl loggerImpl = new PaxLoggerImpl( null, logger, null, null );
+
+        logger.setLevel( null );
+        assertEquals( PaxLogger.LEVEL_ERROR , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.ALL );
+        assertEquals( PaxLogger.LEVEL_TRACE , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.TRACE );
+        assertEquals( PaxLogger.LEVEL_TRACE , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.DEBUG );
+        assertEquals( PaxLogger.LEVEL_DEBUG , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.INFO );
+        assertEquals( PaxLogger.LEVEL_INFO , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.WARN );
+        assertEquals( PaxLogger.LEVEL_WARNING , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.ERROR );
+        assertEquals( PaxLogger.LEVEL_ERROR , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.FATAL );
+        assertEquals( PaxLogger.LEVEL_ERROR , loggerImpl.getLogLevel() );
+
+        logger.setLevel( Level.OFF );
+        assertEquals( PaxLogger.LEVEL_ERROR , loggerImpl.getLogLevel() );
+
+    }
+}
+


### PR DESCRIPTION
org.apache.log4j.Category.getLevel() may return null.

I have some third party code which is calling org.apache.log4j.Category.getEffectiveLevel() which causes a NPE here. (Note there are two Category classes included - one in the api and one in pax-logging-service. This comes through the category class from the api bundle)

java.lang.NullPointerException
	at org.ops4j.pax.logging.service.internal.PaxLoggerImpl.getLogLevel(PaxLoggerImpl.java:303)
	at org.ops4j.pax.logging.internal.TrackingLogger.getLogLevel(TrackingLogger.java:136)
	at org.apache.log4j.Category.getEffectiveLevel(Category.java:378)
