### PR TITLE
Extract only the level not the appender

### DIFF
--- a/pax-logging-logback/src/main/java/org/ops4j/pax/logging/logback/internal/PaxLoggingServiceImpl.java
+++ b/pax-logging-logback/src/main/java/org/ops4j/pax/logging/logback/internal/PaxLoggingServiceImpl.java
@@ -382,17 +382,22 @@ public class PaxLoggingServiceImpl implements PaxLoggingService, org.knopflerfis
           String name = (String) keys.nextElement();
           if ( name.equals( "log4j.rootLogger" ) )
           {
-              Level level = Level.toLevel( (String) config.get( name ) );
+              Level level = extractLevel((String) config.get( name ));
               m_logbackContext.getLogger( org.slf4j.Logger.ROOT_LOGGER_NAME ).setLevel( level );
           }
 
           if ( name.startsWith( "log4j.logger." ) )
           {
-              Level level = Level.toLevel( (String) config.get( name ) );
+              Level level = extractLevel( (String) config.get( name ) );
               String packageName = name.substring( "log4j.logger.".length() );
               m_logbackContext.getLogger( packageName ).setLevel( level );
           }
       }
+    }
+
+    private Level extractLevel(String log4jLevelConfig) {
+        String[] config = log4jLevelConfig.split(",");
+        return Level.toLevel( config[0] );
     }
 
     private void configurePax(Dictionary config) {


### PR DESCRIPTION
We’re switched in karaf from pax-logging-service to pax-logging-logback. After restarting karaf we had a strange behavior. The root logger logged in level DEBUG and ignored every change. The reason was that our Log4j configuration included appenders. If it's include an appender as suffix the log level will be set to DEBUG, because Level.toLevel() compares the whole string. The corresponding method of pax-logging-service extracts only the log level from the property value. The change includes a method to extract the log level.