### PR TITLE
PAXLOGGING-204: upgrade Log4j2

### DIFF
--- a/pax-logging-log4j2/src/main/java/org/apache/logging/log4j/core/config/plugins/util/ResolverUtil.java
+++ b/pax-logging-log4j2/src/main/java/org/apache/logging/log4j/core/config/plugins/util/ResolverUtil.java
@@ -34,7 +34,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.util.Charsets;
 import org.apache.logging.log4j.core.util.Loader;
 import org.apache.logging.log4j.status.StatusLogger;
 import org.osgi.framework.FrameworkUtil;
@@ -236,7 +235,7 @@ public class ResolverUtil {
             // if URL-encoded file exists, don't decode it
             return urlPath;
         }
-        urlPath = URLDecoder.decode(urlPath, Charsets.UTF_8.name());
+        urlPath = URLDecoder.decode(urlPath, "UTF-8");
         return urlPath;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,12 +168,12 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.0.2</version>
+        <version>2.3</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.0.2</version>
+        <version>2.3</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
There were a couple changes from 2.0 to 2.3 that had to be addressed here as well. If this needs to remain compatible with Java 1.6, then 2.3 is the latest version you can use. Otherwise, you can stay up to date (current: 2.4.1).