### PR TITLE
[PAXLOGGING-208] Upgrade to commons logging 1.2

### DIFF
--- a/pax-logging-api/osgi.bnd
+++ b/pax-logging-api/osgi.bnd
@@ -12,9 +12,11 @@ Private-Package: \
 
 Export-Package: \
  org.apache.avalon.framework.logger;-split-package:=merge-first; version=4.3; provider=paxlogging, \
- org.apache.commons.logging; version=1.1.1; provider=paxlogging, \
+ org.apache.commons.logging; version=1.2.0; provider=paxlogging, \
+ org.apache.commons.logging; version=1.1.3; provider=paxlogging, \
  org.apache.commons.logging; version=1.0.4; provider=paxlogging, \
- org.apache.commons.logging.impl; version=1.1.1; provider=paxlogging, \
+ org.apache.commons.logging.impl; version=1.2.0; provider=paxlogging, \
+ org.apache.commons.logging.impl; version=1.1.3; provider=paxlogging, \
  org.apache.commons.logging.impl; version=1.0.4; provider=paxlogging, \
  org.apache.juli.logging; version=5.5.28; provider=paxlogging, \
  org.apache.juli.logging; version=6.0.18; provider=paxlogging, \

--- a/pax-logging-api/src/main/java/org/apache/commons/logging/Log.java
+++ b/pax-logging-api/src/main/java/org/apache/commons/logging/Log.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- * Copyright 2005 Niclas Hedhman
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -14,22 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* NOTE!!!!  This is NOT the original Jakarta Commons Logging, but an adaption
-   of its interface so that this Log4J OSGi bundle can export the JCL interface
-   but redirect permananently to the Log4J implementation
-*/
 
 package org.apache.commons.logging;
 
-import org.osgi.framework.BundleContext;
-
 /**
- * <p>A simple logging interface abstracting logging APIs.  In order to be
+ * A simple logging interface abstracting logging APIs.  In order to be
  * instantiated successfully by {@link LogFactory}, classes that implement
  * this interface must have a constructor that takes a single String
- * parameter representing the "name" of this Log.</p>
- *
- * <p> The six logging levels used by <code>Log</code> are (in order):
+ * parameter representing the "name" of this Log.
+ * <p>
+ * The six logging levels used by <code>Log</code> are (in order):
  * <ol>
  * <li>trace (the least serious)</li>
  * <li>debug</li>
@@ -40,205 +34,183 @@ import org.osgi.framework.BundleContext;
  * </ol>
  * The mapping of these log levels to the concepts used by the underlying
  * logging system is implementation dependent.
- * The implemention should ensure, though, that this ordering behaves
- * as expected.</p>
- *
- * <p>Performance is often a logging concern.
+ * The implementation should ensure, though, that this ordering behaves
+ * as expected.
+ * <p>
+ * Performance is often a logging concern.
  * By examining the appropriate property,
  * a component can avoid expensive operations (producing information
- * to be logged).</p>
- *
- * <p> For example,
- * <code><pre>
+ * to be logged).
+ * <p>
+ * For example,
+ * <pre>
  *    if (log.isDebugEnabled()) {
  *        ... do something expensive ...
  *        log.debug(theResult);
  *    }
- * </pre></code>
- * </p>
- *
- * <p>Configuration of the underlying logging system will generally be done
+ * </pre>
+ * <p>
+ * Configuration of the underlying logging system will generally be done
  * external to the Logging APIs, through whatever mechanism is supported by
- * that system.</p>
+ * that system.
  *
- * @author <a href="mailto:sanders@apache.org">Scott Sanders</a>
- * @author Rod Waldhoff
- * @version $Id: Log.java,v 1.19 2004/06/06 21:16:04 rdonkin Exp $
+ * @version $Id: Log.java 1606045 2014-06-27 12:11:56Z tn $
  */
-public interface Log
-{
+public interface Log {
 
     /**
-     * <p> Is debug logging currently enabled? </p>
+     * Logs a message with debug log level.
      *
-     * <p> Call this method to prevent having to perform expensive operations
+     * @param message log this message
+     */
+    void debug(Object message);
+
+    /**
+     * Logs an error with debug log level.
+     *
+     * @param message log this message
+     * @param t log this cause
+     */
+    void debug(Object message, Throwable t);
+
+    /**
+     * Logs a message with error log level.
+     *
+     * @param message log this message
+     */
+    void error(Object message);
+
+    /**
+     * Logs an error with error log level.
+     *
+     * @param message log this message
+     * @param t log this cause
+     */
+    void error(Object message, Throwable t);
+
+    /**
+     * Logs a message with fatal log level.
+     *
+     * @param message log this message
+     */
+    void fatal(Object message);
+
+    /**
+     * Logs an error with fatal log level.
+     *
+     * @param message log this message
+     * @param t log this cause
+     */
+    void fatal(Object message, Throwable t);
+
+    /**
+     * Logs a message with info log level.
+     *
+     * @param message log this message
+     */
+    void info(Object message);
+
+    /**
+     * Logs an error with info log level.
+     *
+     * @param message log this message
+     * @param t log this cause
+     */
+    void info(Object message, Throwable t);
+
+    /**
+     * Is debug logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than debug. </p>
+     * when the log level is more than debug.
      *
-     * @return true if Debug level is enabled
+     * @return true if debug is enabled in the underlying logger.
      */
     boolean isDebugEnabled();
 
     /**
-     * <p> Is error logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is error logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than error. </p>
+     * when the log level is more than error.
      *
-     * @return true if Error level is enabled
+     * @return true if error is enabled in the underlying logger.
      */
     boolean isErrorEnabled();
 
     /**
-     * <p> Is fatal logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is fatal logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than fatal. </p>
+     * when the log level is more than fatal.
      *
-     * @return true if Fatal level is enabled
+     * @return true if fatal is enabled in the underlying logger.
      */
     boolean isFatalEnabled();
 
     /**
-     * <p> Is info logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is info logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than info. </p>
+     * when the log level is more than info.
      *
-     * @return true if Info level is enabled
+     * @return true if info is enabled in the underlying logger.
      */
     boolean isInfoEnabled();
 
     /**
-     * <p> Is trace logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is trace logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than trace. </p>
+     * when the log level is more than trace.
      *
-     * @return true if Trace level is enabled
+     * @return true if trace is enabled in the underlying logger.
      */
     boolean isTraceEnabled();
 
     /**
-     * <p> Is warn logging currently enabled? </p>
-     *
-     * <p> Call this method to prevent having to perform expensive operations
+     * Is warn logging currently enabled?
+     * <p>
+     * Call this method to prevent having to perform expensive operations
      * (for example, <code>String</code> concatenation)
-     * when the log level is more than warn. </p>
+     * when the log level is more than warn.
      *
-     * @return true if Warn level is enabled
+     * @return true if warn is enabled in the underlying logger.
      */
     boolean isWarnEnabled();
 
     /**
-     * <p> Log a message with trace log level. </p>
+     * Logs a message with trace log level.
      *
      * @param message log this message
      */
-    void trace( Object message );
+    void trace(Object message);
 
     /**
-     * <p> Log an error with trace log level. </p>
+     * Logs an error with trace log level.
      *
      * @param message log this message
-     * @param t       log this cause
+     * @param t log this cause
      */
-    void trace( Object message, Throwable t );
+    void trace(Object message, Throwable t);
 
     /**
-     * <p> Log a message with debug log level. </p>
-     *
-     * @param message log this message
-     */
-    void debug( Object message );
-
-    /**
-     * <p> Log an error with debug log level. </p>
-     *
-     * @param message log this message
-     * @param t       log this cause
-     */
-    void debug( Object message, Throwable t );
-
-    /**
-     * <p> Log a message with info log level. </p>
+     * Logs a message with warn log level.
      *
      * @param message log this message
      */
-    void info( Object message );
+    void warn(Object message);
 
     /**
-     * <p> Log an error with info log level. </p>
+     * Logs an error with warn log level.
      *
      * @param message log this message
-     * @param t       log this cause
+     * @param t log this cause
      */
-    void info( Object message, Throwable t );
-
-    /**
-     * <p> Log a message with warn log level. </p>
-     *
-     * @param message log this message
-     */
-    void warn( Object message );
-
-    /**
-     * <p> Log an error with warn log level. </p>
-     *
-     * @param message log this message
-     * @param t       log this cause
-     */
-    void warn( Object message, Throwable t );
-
-    /**
-     * <p> Log a message with error log level. </p>
-     *
-     * @param message log this message
-     */
-    void error( Object message );
-
-    /**
-     * <p> Log an error with error log level. </p>
-     *
-     * @param message log this message
-     * @param t       log this cause
-     */
-    void error( Object message, Throwable t );
-
-    /**
-     * <p> Log a message with fatal log level. </p>
-     *
-     * @param message log this message
-     */
-    void fatal( Object message );
-
-    /**
-     * <p> Log an error with fatal log level. </p>
-     *
-     * @param message log this message
-     * @param t       log this cause
-     */
-    void fatal( Object message, Throwable t );
-
-    /**
-     * Returns the LogLevel of the Logger.
-     * The LogLevels are
-     * <pre>
-     * Integer.MAX_INT = OFF
-     * FATAL = 50000
-     * ERROR = 40000
-     * WARN  = 30000
-     * INFO  = 20000
-     * DEBUG = 10000
-     * TRACE = 5000
-     * ALL = Integer.MIN_VALUE
-     * </pre>
-     *
-     * @return the numeric value of the current level.
-     */
-    int getLogLevel();
+    void warn(Object message, Throwable t);
 }

--- a/pax-logging-api/src/main/java/org/apache/commons/logging/LogConfigurationException.java
+++ b/pax-logging-api/src/main/java/org/apache/commons/logging/LogConfigurationException.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2001-2004 The Apache Software Foundation.
- * Copyright 2005 Niclas Hedhman
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -14,32 +14,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* NOTE!!!!  This is NOT the original Jakarta Commons Logging, but an adaption
-   of its interface so that this Log4J OSGi bundle can export the JCL interface
-   but redirect permananently to the Log4J implementation
-*/
-
 
 package org.apache.commons.logging;
 
-
 /**
-* <p>An exception that is thrown only if a suitable <code>LogFactory</code>
-* or <code>Log</code> instance cannot be created by the corresponding
-* factory methods.</p>
-*
-* @author Craig R. McClanahan
-* @version $Revision: 1.6 $ $Date: 2004/02/28 21:46:45 $
-*/
-public class LogConfigurationException extends RuntimeException
-{
-    private static final long serialVersionUID = 1L;
+ * An exception that is thrown only if a suitable <code>LogFactory</code>
+ * or <code>Log</code> instance cannot be created by the corresponding
+ * factory methods.
+ *
+ * @version $Id: LogConfigurationException.java 1432663 2013-01-13 17:24:18Z tn $
+ */
+public class LogConfigurationException extends RuntimeException {
+
+    /** Serializable version identifier. */
+    private static final long serialVersionUID = 8486587136871052495L;
 
     /**
      * Construct a new exception with <code>null</code> as its detail message.
      */
-    public LogConfigurationException()
-    {
+    public LogConfigurationException() {
         super();
     }
 
@@ -48,8 +41,7 @@ public class LogConfigurationException extends RuntimeException
      *
      * @param message The detail message
      */
-    public LogConfigurationException(String message)
-    {
+    public LogConfigurationException(String message) {
         super(message);
     }
 
@@ -59,9 +51,8 @@ public class LogConfigurationException extends RuntimeException
      *
      * @param cause The underlying cause
      */
-    public LogConfigurationException(Throwable cause)
-    {
-        this((cause == null) ? null : cause.toString(), cause);
+    public LogConfigurationException(Throwable cause) {
+        this(cause == null ? null : cause.toString(), cause);
     }
 
     /**
@@ -70,8 +61,7 @@ public class LogConfigurationException extends RuntimeException
      * @param message The detail message
      * @param cause The underlying cause
      */
-    public LogConfigurationException(String message, Throwable cause)
-    {
+    public LogConfigurationException(String message, Throwable cause) {
         super(message + " (Caused by " + cause + ")");
         this.cause = cause; // Two-argument version requires JDK 1.4 or later
     }
@@ -79,14 +69,12 @@ public class LogConfigurationException extends RuntimeException
     /**
      * The underlying cause of this exception.
      */
-     protected Throwable cause = null;
+    protected Throwable cause = null;
 
     /**
      * Return the underlying cause of this exception (if any).
      */
-    public Throwable getCause()
-    {
-        return (this.cause);
+    public Throwable getCause() {
+        return this.cause;
     }
 }
-

--- a/pax-logging-api/src/main/java/org/apache/commons/logging/impl/NoOpLog.java
+++ b/pax-logging-api/src/main/java/org/apache/commons/logging/impl/NoOpLog.java
@@ -1,123 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.commons.logging.impl;
 
+import java.io.Serializable;
 import org.apache.commons.logging.Log;
 
-public class NoOpLog
-    implements Log
-{
+/**
+ * Trivial implementation of Log that throws away all messages.  No
+ * configurable system properties are supported.
+ *
+ * @version $Id: NoOpLog.java 1432663 2013-01-13 17:24:18Z tn $
+ */
+public class NoOpLog implements Log, Serializable {
 
-    public void debug(Object message)
-    {
-        // do nothing
+    /** Serializable version identifier. */
+    private static final long serialVersionUID = 561423906191706148L;
 
-    }
+    /** Convenience constructor */
+    public NoOpLog() { }
+    /** Base constructor */
+    public NoOpLog(String name) { }
+    /** Do nothing */
+    public void trace(Object message) { }
+    /** Do nothing */
+    public void trace(Object message, Throwable t) { }
+    /** Do nothing */
+    public void debug(Object message) { }
+    /** Do nothing */
+    public void debug(Object message, Throwable t) { }
+    /** Do nothing */
+    public void info(Object message) { }
+    /** Do nothing */
+    public void info(Object message, Throwable t) { }
+    /** Do nothing */
+    public void warn(Object message) { }
+    /** Do nothing */
+    public void warn(Object message, Throwable t) { }
+    /** Do nothing */
+    public void error(Object message) { }
+    /** Do nothing */
+    public void error(Object message, Throwable t) { }
+    /** Do nothing */
+    public void fatal(Object message) { }
+    /** Do nothing */
+    public void fatal(Object message, Throwable t) { }
 
-    public void debug(Object message, Throwable t)
-    {
-        // do nothing
+    /**
+     * Debug is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isDebugEnabled() { return false; }
 
-    }
+    /**
+     * Error is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isErrorEnabled() { return false; }
 
-    public void error(Object message)
-    {
-        // do nothing
+    /**
+     * Fatal is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isFatalEnabled() { return false; }
 
-    }
+    /**
+     * Info is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isInfoEnabled() { return false; }
 
-    public void error(Object message, Throwable t)
-    {
-        // do nothing
+    /**
+     * Trace is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isTraceEnabled() { return false; }
 
-    }
-
-    public void fatal(Object message)
-    {
-        // do nothing
-
-    }
-
-    public void fatal(Object message, Throwable t)
-    {
-        // do nothing
-
-    }
-
-    public int getLogLevel()
-    {
-        // do nothing
-        return 0;
-    }
-
-    public void info(Object message)
-    {
-        // do nothing
-
-    }
-
-    public void info(Object message, Throwable t)
-    {
-        // do nothing
-
-    }
-
-    public boolean isDebugEnabled()
-    {
-        // do nothing
-        return false;
-    }
-
-    public boolean isErrorEnabled()
-    {
-        // do nothing
-        return false;
-    }
-
-    public boolean isFatalEnabled()
-    {
-        // do nothing
-        return false;
-    }
-
-    public boolean isInfoEnabled()
-    {
-        // do nothing
-        return false;
-    }
-
-    public boolean isTraceEnabled()
-    {
-        // do nothing
-        return false;
-    }
-
-    public boolean isWarnEnabled()
-    {
-        // do nothing
-        return false;
-    }
-
-    public void trace(Object message)
-    {
-        // do nothing
-
-    }
-
-    public void trace(Object message, Throwable t)
-    {
-        // do nothing
-
-    }
-
-    public void warn(Object message)
-    {
-        // do nothing
-
-    }
-
-    public void warn(Object message, Throwable t)
-    {
-        // do nothing
-
-    }
-
+    /**
+     * Warn is never enabled.
+     *
+     * @return false
+     */
+    public final boolean isWarnEnabled() { return false; }
 }


### PR DESCRIPTION
Now exports both 1.2 and 1.1.3 versions of the commons logging packages.

I replaced the current version of the org.apache.commons.logging packages with the one from commons-logging-1.2. To fix the compilation errors, I have removed all files not yet in VCS and I reverted the changes in LogFactory (as the implementation is completely different opposed to the version of commons logging). However, Unit Tests run successfully.