### PR TITLE
Code quality fix - "public static" fields should be constant.

### DIFF
--- a/pax-logging-api/src/main/java/org/slf4j/helpers/FormattingTuple.java
+++ b/pax-logging-api/src/main/java/org/slf4j/helpers/FormattingTuple.java
@@ -31,7 +31,7 @@ package org.slf4j.helpers;
  */
 public class FormattingTuple {
 
-    static public FormattingTuple NULL = new FormattingTuple(null);
+    static final public FormattingTuple NULL = new FormattingTuple(null);
 
     private String message;
     private Throwable throwable;

--- a/pax-logging-api/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/pax-logging-api/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -57,7 +57,7 @@ public class StaticLoggerBinder {
    * The value of this field is usually modified with each release.
    */
   // to avoid constant folding by the compiler, this field must *not* be final
-  public static String REQUESTED_API_VERSION = "1.6.99";  // !final
+  public static final String REQUESTED_API_VERSION = "1.6.99";  // !final
 
   /**
    * Return the singleton of this class.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Faisal Hameed