### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/pax-logging-api/src/main/java/org/apache/log4j/MDC.java
+++ b/pax-logging-api/src/main/java/org/apache/log4j/MDC.java
@@ -30,6 +30,10 @@ public class MDC {
     private static PaxContext m_context;
     private static PaxContext m_defaultContext = new PaxContext();
     private static PaxLoggingManager m_paxLogging;
+    
+    private MDC() 
+    {
+    }
 
     public static void setBundleContext(BundleContext ctx) {
         m_paxLogging = new OSGIPaxLoggingManager(ctx);

--- a/pax-logging-api/src/main/java/org/apache/log4j/internal/MessageFormatter.java
+++ b/pax-logging-api/src/main/java/org/apache/log4j/internal/MessageFormatter.java
@@ -28,6 +28,10 @@ public class MessageFormatter
 
     static final char DELIM_START = '{';
     static final char DELIM_STOP = '}';
+    
+    private MessageFormatter() 
+    {
+    }
 
     /**
      * Performs single argument substitution for the 'messagePattern' passed as

--- a/pax-logging-api/src/main/java/org/knopflerfish/service/log/LogUtil.java
+++ b/pax-logging-api/src/main/java/org/knopflerfish/service/log/LogUtil.java
@@ -43,6 +43,11 @@ import org.osgi.service.log.LogService;
  */
 
 public class LogUtil {
+    
+    private LogUtil()
+    {
+    }
+    
     /**
      * * Converts from a numeric log severity level to a string. * *
      * 

--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/avalon/AvalonLogFactory.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/avalon/AvalonLogFactory.java
@@ -33,6 +33,10 @@ public class AvalonLogFactory
 
     private static PaxLoggingManager m_paxLogging;
     private static Map<String, AvalonLogger> m_loggers;
+    
+    private AvalonLogFactory() 
+    {
+    }
 
     static
     {

--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/internal/FallbackLogFactory.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/internal/FallbackLogFactory.java
@@ -29,6 +29,11 @@ import org.ops4j.pax.logging.PaxLogger;
  */
 public class FallbackLogFactory
 {
+    
+    private FallbackLogFactory() 
+    {
+    }
+    
     public static PaxLogger createFallbackLog( Bundle bundle, String categoryName )
     {
         if( isBuffering() )

--- a/pax-logging-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
+++ b/pax-logging-api/src/main/java/org/slf4j/helpers/MessageFormatter.java
@@ -100,6 +100,10 @@ final public class MessageFormatter {
     static final char DELIM_STOP = '}';
     static final String DELIM_STR = "{}";
     private static final char ESCAPE_CHAR = '\\';
+    
+    private MessageFormatter() 
+    {
+    }
 
     /**
      * Performs single argument substitution for the 'messagePattern' passed as

--- a/pax-logging-service/src/main/java/org/apache/log4j/receivers/db/DBHelper.java
+++ b/pax-logging-service/src/main/java/org/apache/log4j/receivers/db/DBHelper.java
@@ -33,6 +33,10 @@ public class DBHelper {
   public final static short PROPERTIES_EXIST = 0x01;
   public final static short EXCEPTION_EXISTS = 0x02;
   
+  private DBHelper()
+  {
+  }
+  
   public  static short computeReferenceMask(LoggingEvent event) {
     short mask = 0;
     Set propertiesKeys = event.getPropertyKeySet();

--- a/pax-logging-service/src/main/java/org/ops4j/pax/logging/util/OsgiUtil.java
+++ b/pax-logging-service/src/main/java/org/ops4j/pax/logging/util/OsgiUtil.java
@@ -37,6 +37,10 @@ public class OsgiUtil {
     
     private static final int osgiVersion;
     
+    private OsgiUtil()
+    {
+    }
+    
     static {
         //
         // The org.osgi.framework package has had no code change from 1.1 to 1.2


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
