### PR TITLE
Code quality fix - "final" classes should not have "protected" members.

### DIFF
--- a/pax-logging-api/src/main/java/org/apache/logging/log4j/Level.java
+++ b/pax-logging-api/src/main/java/org/apache/logging/log4j/Level.java
@@ -321,7 +321,7 @@ public final class Level implements Comparable<Level>, Serializable {
     }
 
     // for deserialization
-    protected Object readResolve() {
+    private Object readResolve() {
         return Level.valueOf(this.name);
     }
 }

--- a/pax-logging-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
+++ b/pax-logging-api/src/main/java/org/apache/logging/log4j/util/ProviderUtil.java
@@ -39,19 +39,19 @@ public final class ProviderUtil {
     /**
      * Resource name for a Log4j 2 provider properties file.
      */
-    protected static final String PROVIDER_RESOURCE = "META-INF/log4j-provider.properties";
+    private static final String PROVIDER_RESOURCE = "META-INF/log4j-provider.properties";
 
     /**
      * Loaded providers.
      */
-    protected static final Collection<Provider> PROVIDERS = new HashSet<>();
+    private static final Collection<Provider> PROVIDERS = new HashSet<>();
 
     /**
      * Guards the ProviderUtil singleton instance from lazy initialization. This is primarily used for OSGi support.
      *
      * @since 2.1
      */
-    protected static final Lock STARTUP_LOCK = new ReentrantLock();
+    private static final Lock STARTUP_LOCK = new ReentrantLock();
 
     private static final String API_VERSION = "Log4jAPIVersion";
     private static final String[] COMPATIBLE_API_VERSIONS = {"2.0.0", "2.1.0"};
@@ -74,7 +74,7 @@ public final class ProviderUtil {
      * @param url the URL to the provider properties file
      * @param cl the ClassLoader to load the provider classes with
      */
-    protected static void loadProvider(final URL url, final ClassLoader cl) {
+    private static void loadProvider(final URL url, final ClassLoader cl) {
         try {
             final Properties props = PropertiesUtil.loadClose(url.openStream(), url);
             if (validVersion(props.getProperty(API_VERSION))) {
@@ -89,7 +89,7 @@ public final class ProviderUtil {
      * @deprecated Use {@link #loadProvider(java.net.URL, ClassLoader)} instead. Will be removed in 3.0.
      */
     @Deprecated
-    protected static void loadProviders(final Enumeration<URL> urls, final ClassLoader cl) {
+    private static void loadProviders(final Enumeration<URL> urls, final ClassLoader cl) {
         if (urls != null) {
             while (urls.hasMoreElements()) {
                 loadProvider(urls.nextElement(), cl);
@@ -112,7 +112,7 @@ public final class ProviderUtil {
      *
      * @since 2.1
      */
-    protected static void lazyInit() {
+    private static void lazyInit() {
         // noinspection DoubleCheckedLocking
         if (instance == null) {
             try {

--- a/pax-logging-api/src/main/java/org/apache/logging/log4j/util/ReflectionUtil.java
+++ b/pax-logging-api/src/main/java/org/apache/logging/log4j/util/ReflectionUtil.java
@@ -303,7 +303,7 @@ public final class ReflectionUtil {
             return super.getClassContext();
         }
 
-        protected Class<?> getCallerClass(final String fqcn, final String pkg) {
+        private Class<?> getCallerClass(final String fqcn, final String pkg) {
             boolean next = false;
             for (final Class<?> clazz : getClassContext()) {
                 if (fqcn.equals(clazz.getName())) {
@@ -318,7 +318,7 @@ public final class ReflectionUtil {
             return null;
         }
 
-        protected Class<?> getCallerClass(final Class<?> anchor) {
+        private Class<?> getCallerClass(final Class<?> anchor) {
             boolean next = false;
             for (final Class<?> clazz : getClassContext()) {
                 if (anchor.equals(clazz)) {

--- a/pax-logging-service/src/main/java/org/apache/log4j/OsgiThrowableRenderer.java
+++ b/pax-logging-service/src/main/java/org/apache/log4j/OsgiThrowableRenderer.java
@@ -56,7 +56,7 @@ public final class OsgiThrowableRenderer implements ThrowableRenderer {
         return DefaultThrowableRenderer.render(throwable);
     }
 
-    protected void doRender(final Throwable throwable, StackTraceElement[]  causedTrace, List lines) {
+    private void doRender(final Throwable throwable, StackTraceElement[]  causedTrace, List lines) {
         StackTraceElement[] elements = throwable.getStackTrace();
         Map classMap = new HashMap();
         Class[] classCtx;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2156 -  "final" classes should not have "protected" members. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2156

Please let me know if you have any questions.

Faisal Hameed
