### PR TITLE
pax-logging-logback: Allow to skip reset of JUL

### DIFF
--- a/pax-logging-logback/src/main/java/org/ops4j/pax/logging/logback/internal/Activator.java
+++ b/pax-logging-logback/src/main/java/org/ops4j/pax/logging/logback/internal/Activator.java
@@ -133,7 +133,11 @@ public class Activator implements BundleActivator {
         if( !Boolean.valueOf(bundleContext.getProperty("org.ops4j.pax.logging.skipJUL")) )
         {
             LogManager manager = LogManager.getLogManager();
-            manager.reset();
+
+            if( !Boolean.valueOf(bundleContext.getProperty("org.ops4j.pax.logging.skipJULReset")) )
+            {
+                manager.reset();
+            }
 
             // clear out old handlers
             Logger rootLogger = manager.getLogger( "" );


### PR DESCRIPTION
We configure logback with
````
  <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
    <resetJUL>true</resetJUL>
  </contextListener>
````
as recommended for performant logging with JUL+SLF4J.

`LevelChangePropagator` however only works in one direction, pushing logback configuration into JUL, it does not account for JUL configuration being changed behind its back. But this is what happens currently due to that unconditional `manager.reset()` call:
- when the bundle activator creates `PaxLoggingServiceImpl` on line 126 and thereby boots/configures logback, log levels for logback are set and synchronized to JUL
- when `manager.reset()` runs next, the JUL log levels are reset, i.e. default to INFO level, causing a disconnect between JUL and logback such that (logback) loggers that have enabled DEBUG level never receive messages because the originating JUL logger drops anything below INFO before the `JdkHandler` is reached