### PR TITLE
Init of PAXContext at bundle activation for Log4J2ThreadContext

### DIFF
--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/log4jv2/Log4jv2LoggerContext.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/log4jv2/Log4jv2LoggerContext.java
@@ -43,10 +43,11 @@ public class Log4jv2LoggerContext implements LoggerContext {
             logger.setPaxLoggingManager(paxLogging);
         }
         paxLogging.open();
+        
+        Log4jv2ThreadContextMap.setPaxLoggingManager(paxLogging);
     }
 
     public static void dispose() {
-
     }
 
     public Log4jv2LoggerContext() {

--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/log4jv2/Log4jv2ThreadContextMap.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/log4jv2/Log4jv2ThreadContextMap.java
@@ -24,10 +24,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.logging.log4j.spi.ThreadContextMap;
-import org.ops4j.pax.logging.OSGIPaxLoggingManager;
 import org.ops4j.pax.logging.PaxContext;
 import org.ops4j.pax.logging.PaxLoggingManager;
-import org.osgi.framework.BundleContext;
 
 /**
  * The actual ThreadContext Map. A new ThreadContext Map is created each time it is updated and the Map stored is always
@@ -42,11 +40,8 @@ public class Log4jv2ThreadContextMap implements ThreadContextMap {
 
     private static PaxLoggingManager m_paxLogging;
 
-    public static void setBundleContext( BundleContext ctx )
-    {
-        m_paxLogging = new OSGIPaxLoggingManager( ctx );
-        // We need to instruct all loggers to ensure the SimplePaxLoggingManager is replaced.
-        m_paxLogging.open();
+    public static void setPaxLoggingManager(PaxLoggingManager plm) {
+    		m_paxLogging = plm;
     }
 
     public static void dispose()

--- a/pax-logging-log4j2/src/main/java/org/ops4j/pax/logging/log4j2/internal/PaxLoggerImpl.java
+++ b/pax-logging-log4j2/src/main/java/org/ops4j/pax/logging/log4j2/internal/PaxLoggerImpl.java
@@ -93,15 +93,8 @@ public class PaxLoggerImpl
         return m_delegate.isFatalEnabled();
     }
 
-    private void setDelegateContext()
+    private void setBundleInfos()
     {
-        Map<String, Object> context = getPaxContext().getContext();
-        if( context != null )
-        {
-            for (Map.Entry<String, Object> entry : context.entrySet()) {
-                put(entry.getKey(), entry.getValue());
-            }
-        }
         if (m_bundle != null)
         {
             BundleRevision rev = m_bundle.adapt(BundleRevision.class);
@@ -125,11 +118,6 @@ public class PaxLoggerImpl
         }
     }
 
-    private void clearDelegateContext()
-    {
-        ThreadContext.clearMap();
-    }
-
     private void doLog(final Level level, final int svcLevel, final String fqcn, final String message, final Throwable t ) {
         if (System.getSecurityManager() != null) {
             AccessController.doPrivileged(
@@ -146,10 +134,9 @@ public class PaxLoggerImpl
     }
 
     private void doLog0( Level level, int svcLevel, final String fqcn, String message, Throwable t ) {
-        setDelegateContext();
+        setBundleInfos();
         Message msg = m_delegate.getMessageFactory().newMessage(message);
         m_delegate.logMessage(fqcn, level, null, msg, t);
-        clearDelegateContext();
         m_service.handleEvents( m_bundle, null, svcLevel, message, t );
     }
 


### PR DESCRIPTION
This is my first pull request so sorry if i'm inadvertently doing something wrong...

I tried to fix the Log4J2ThreadContext so that i can use Log4J2 ThreadContext API without using PaxContext directly.

The problem was that the context was cleansed after each log.

