### PR TITLE
[PAXLOGGING-247] Always use fresh instance of PaxLoggingService

### DIFF
--- a/pax-logging-api/src/main/java/org/apache/log4j/MDC.java
+++ b/pax-logging-api/src/main/java/org/apache/log4j/MDC.java
@@ -44,7 +44,7 @@ public class MDC {
      * or if the logging manager is not set, or does not have its context available yet, use a default context local to this MDC.
      */
     private static boolean setContext() {
-        if (m_context == null && m_paxLogging != null) {
+        if (m_paxLogging != null) {
             m_context = (m_paxLogging.getPaxLoggingService() != null) ? m_paxLogging.getPaxLoggingService().getPaxContext() : null;
         }
         return m_context != null;

--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/slf4j/Slf4jMDCAdapter.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/slf4j/Slf4jMDCAdapter.java
@@ -46,7 +46,7 @@ public class Slf4jMDCAdapter
       * or m_defaultContext if the logging manager is not set, or does not have its context available yet.
       */
     private static PaxContext getContext(){
-        if( m_context==null && m_paxLogging!=null ){
+        if( m_paxLogging!=null ){
             m_context=(m_paxLogging.getPaxLoggingService()!=null)?m_paxLogging.getPaxLoggingService().getPaxContext():null;
         }
         return m_context!=null?m_context:m_defaultContext;


### PR DESCRIPTION
It's a cheap operation, because both:
* org.ops4j.pax.logging.OSGIPaxLoggingManager#getPaxLoggingService(), and
* org.ops4j.pax.logging.service.internal.PaxLoggingServiceImpl#getPaxContext()
are just getters.