### PR TITLE
[PAXLOGGING-243] Fixed PaxLoggingServiceImpl which returned logger from different bundle

### DIFF
--- a/pax-logging-log4j2/src/main/java/org/ops4j/pax/logging/log4j2/internal/PaxLoggingServiceImpl.java
+++ b/pax-logging-log4j2/src/main/java/org/ops4j/pax/logging/log4j2/internal/PaxLoggingServiceImpl.java
@@ -131,12 +131,13 @@ public class PaxLoggingServiceImpl
     public PaxLogger getLogger( Bundle bundle, String category, String fqcn )
     {
         String name = category == null ? LogManager.ROOT_LOGGER_NAME : category;
-        PaxLoggerImpl logger = m_loggers.get( name );
+        String key = fqcn + "#" + name + "#" + (bundle != null ? Long.toString(bundle.getBundleId()) : "0");
+        PaxLoggerImpl logger = m_loggers.get( key );
         if (logger == null) {
             logger = new PaxLoggerImpl( bundle, m_log4jContext.getLogger(name), fqcn, this );
-            m_loggers.putIfAbsent( name, logger );
+            m_loggers.putIfAbsent( key, logger );
         }
-        return m_loggers.get( name );
+        return m_loggers.get( key );
     }
 
     public synchronized void updated( Dictionary<String,?> configuration ) throws ConfigurationException


### PR DESCRIPTION
Solved by reusing the ops4j manager solution to this problem
https://github.com/ops4j/org.ops4j.pax.logging/blob/master/pax-logging-api/src/main/java/org/ops4j/pax/logging/OSGIPaxLoggingManager.java

Bundle bundle = BundleHelper.getCallerBundle(m_context.getBundle());
String key = fqcn + "#" + category + "#" + (bundle != null ?
Long.toString(bundle.getBundleId()) : "0");