### PR TITLE
Add Kafka serialization package to imports in pax-logging-log4j2-extra

### DIFF
--- a/pax-logging-log4j2-extra/osgi.bnd
+++ b/pax-logging-log4j2-extra/osgi.bnd
@@ -61,6 +61,7 @@ Import-Package: \
  org.apache.commons.compress.utils ;resolution:=optional, \
  org.apache.commons.csv ;resolution:=optional, \
  org.apache.kafka.clients.producer ;resolution:=optional, \
+ org.apache.kafka.common.serialization ;resolution:=optional, \
  org.codehaus.stax2 ;resolution:=optional, \
  org.fusesource.jansi ;resolution:=optional, \
  org.jctools.queues ;resolution:=optional, \


### PR DESCRIPTION
While attempting to configure Log4J2's Kafka Appender in OSGi, the following exception is thrown:

```
org.ops4j.pax.logging.pax-logging-api [log4j2] ERROR : Log4J2 configuration problem: Invalid value org.apache.kafka.common.serialization.ByteArraySerializer for configuration key.serializer: Class org.apache.kafka.common.serialization.ByteArraySerializer could not be found. Ignored FQCN: org.apache.logging.log4j.spi.AbstractLogger
org.apache.kafka.common.config.ConfigException: Invalid value org.apache.kafka.common.serialization.ByteArraySerializer for configuration key.serializer: Class org.apache.kafka.common.serialization.ByteArraySerializer could not be found.
	at org.apache.kafka.common.config.ConfigDef.parseType(ConfigDef.java:728)
	at org.apache.kafka.common.config.ConfigDef.parseValue(ConfigDef.java:474)
	at org.apache.kafka.common.config.ConfigDef.parse(ConfigDef.java:467)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:108)
	at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:129)
	at org.apache.kafka.clients.producer.ProducerConfig.<init>(ProducerConfig.java:481)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:326)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:298)
	at org.apache.logging.log4j.core.appender.mom.kafka.DefaultKafkaProducerFactory.newKafkaProducer(DefaultKafkaProducerFactory.java:40)
	at org.apache.logging.log4j.core.appender.mom.kafka.KafkaManager.startup(KafkaManager.java:136)
	at org.apache.logging.log4j.core.appender.mom.kafka.KafkaAppender.start(KafkaAppender.java:169)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.start(AbstractConfiguration.java:304)
	at org.apache.logging.log4j.core.LoggerContext.setConfiguration(LoggerContext.java:618)
	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:295)
	at org.ops4j.pax.logging.log4j2.internal.PaxLoggingServiceImpl.configureLog4J2(PaxLoggingServiceImpl.java:425)
	at org.ops4j.pax.logging.log4j2.internal.PaxLoggingServiceImpl.updated(PaxLoggingServiceImpl.java:277)
	at org.ops4j.pax.logging.log4j2.internal.PaxLoggingServiceImpl$1ManagedPaxLoggingService.updated(PaxLoggingServiceImpl.java:585)
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updated(ManagedServiceTracker.java:189)
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.updateService(ManagedServiceTracker.java:152)
	at org.apache.felix.cm.impl.helper.ManagedServiceTracker.provideConfiguration(ManagedServiceTracker.java:85)
	at org.apache.felix.cm.impl.ConfigurationManager$UpdateConfiguration.run(ConfigurationManager.java:1405)
	at org.apache.felix.cm.impl.UpdateThread.run0(UpdateThread.java:138)
	at org.apache.felix.cm.impl.UpdateThread.run(UpdateThread.java:105)
	at java.lang.Thread.run(Thread.java:748)
```

Adding org.apache.kafka.common.serialization to the list of imported packages in pax-logging-log4j2-extra resolves this error and allows the Kafka Appender to be configured.

This is tested with org.ops4j.pax.logging/pax-logging-log4j2/1.11.4 and org.apache.servicemix.bundles/org.apache.servicemix.bundles.kafka-clients/2.5.0_1. No additional package dependencies have been encountered.

Thanks in advance!