### PR TITLE
Fix TLS debug logging after the backport of TLSv1.3 in java

### DIFF
--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/PaxLoggingConstants.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/PaxLoggingConstants.java
@@ -87,6 +87,16 @@ public interface PaxLoggingConstants {
     String LOGGING_CFG_USE_FILE_FALLBACK_LOGGER = "org.ops4j.pax.logging.useFileLogFallback";
 
     /**
+     * System property that specifies the TLS debug logging mode. The TLS records logging modes are:
+     * <ul>
+     *     <li>no_logging - TLS messages are not logged</li>
+     *     <li>no_hex_dumps_logging - all messages except hex dumps are logged</li>
+     *     <li>debug_logging - all messages are logged</li>
+     * </ul>
+     */
+    String LOGGING_CFG_TLS_LOGGING_MODE = "org.ops4j.pax.logging.tlsdebug.loggingMode";
+
+    /**
      * {@code org.osp4j.pax.logging} PID property to specify max size for
      * {@link org.osgi.service.log.LogReaderService}
      */

--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/internal/JdkHandler.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/internal/JdkHandler.java
@@ -91,7 +91,7 @@ public class JdkHandler extends Handler {
         String message;
         try {
             if (TLS_DEBUG_LOGGER.equals(loggerName)) {
-                // The TLS debug log records contain an additional string parameter with attachments
+                // The TLS debug log records contain additional string parameters with attachments
                 // (hex dumps, handshake messages etc). They are without a format parameter in the log message,
                 // so they are not parsed by the JUL formatter.
                 message = getTLSLogMessage(record);

--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/internal/JdkHandler.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/internal/JdkHandler.java
@@ -17,12 +17,16 @@
  */
 package org.ops4j.pax.logging.internal;
 
+import java.util.Objects;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.ops4j.pax.logging.PaxLogger;
+import org.ops4j.pax.logging.PaxLoggingConstants;
 import org.ops4j.pax.logging.PaxLoggingManager;
 
 /**
@@ -32,10 +36,28 @@ import org.ops4j.pax.logging.PaxLoggingManager;
  * {@link java.util.logging.Formatter#formatMessage(LogRecord)} which only uses
  * {@link java.text.MessageFormat#format(String, Object...)} method on log record's message.
  * It doesn't do anything with remaining fields of {@link LogRecord}.
+ * <p>
+ * Since the backport of TLSv1.3 in java (JDK-8248721) the logic of TLS debug traces has been changed.
+ * The new TLS debug logger uses a configured JUL logger when you define the system property "javax.net.debug"
+ * as empty. The TLS log records contain additional string parameters. They are without format parameters in
+ * the log message. The {@link JdkHandler} appends them to the end of the TLS log message.
+ * <p>
+ * The {@link JdkHandler} has the following logging modes for the TLS log records:
+ *  <ul>
+ *      <li>no_logging - TLS messages are not logged</li>
+ *      <li>no_hex_dumps_logging - all messages except hex dumps are logged</li>
+ *      <li>debug_logging - all messages are logged</li>
+ *  </ul>
+ *  The logging mode is determined by the value of the {@value PaxLoggingConstants#LOGGING_CFG_TLS_LOGGING_MODE}
+ *  system property.
  */
 public class JdkHandler extends Handler {
 
     private static final String FQCN = java.util.logging.Logger.class.getName();
+    private static final String TLS_DEBUG_LOGGER = "javax.net.ssl";
+    private static final String NO_LOGGING_MODE = "no_logging";
+    private static final String DEBUG_LOGGING_MODE = "debug_logging";
+    private static final String HEX_DUMP_OFFSET = "0000:";
 
     private PaxLoggingManager m_loggingManager;
 
@@ -61,11 +83,23 @@ public class JdkHandler extends Handler {
         Level level = record.getLevel();
         String loggerName = record.getLoggerName();
         PaxLogger logger = m_loggingManager.getLogger(loggerName, FQCN);
+
+        if (TLS_DEBUG_LOGGER.equals(loggerName) && !isTLSDebugLoggingEnabled()) {
+            return;
+        }
+
         String message;
         try {
-            // LogRecord may have parameters associated, so let's format the message
-            // using JUL formatter
-            message = getFormatter().formatMessage(record);
+            if (TLS_DEBUG_LOGGER.equals(loggerName)) {
+                // The TLS debug log records contain an additional string parameter with attachments
+                // (hex dumps, handshake messages etc). They are without a format parameter in the log message,
+                // so they are not parsed by the JUL formatter.
+                message = getTLSLogMessage(record);
+            } else {
+                // LogRecord may have parameters associated, so let's format the message
+                // using JUL formatter
+                message = getFormatter().formatMessage(record);
+            }
         } catch (Exception ex) {
             message = record.getMessage();
         }
@@ -99,4 +133,55 @@ public class JdkHandler extends Handler {
         }
     }
 
+    /**
+     * Appends the TLS log record parameters to the end of the TLS log message.
+     *
+     * @param logRecord The TLS log record.
+     */
+    private String getTLSLogMessage(LogRecord logRecord) {
+        String message;
+        try {
+            message = logRecord.getMessage();
+            if (logRecord.getParameters() != null) {
+                String tlsLoggingModeProperty = System.getProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE);
+                boolean isDebugLoggingEnabled = DEBUG_LOGGING_MODE.equals(tlsLoggingModeProperty);
+
+                String logParameters = Stream.of(logRecord.getParameters())
+                        .filter(Objects::nonNull)
+                        .filter(String.class::isInstance)
+                        .map(String::valueOf)
+                        // hex dump parameters are not filtered only if the TLS logging mode is "debug logging"
+                        .filter(x -> !isHexDumpMessage(x) || isDebugLoggingEnabled)
+                        .collect(Collectors.joining(System.lineSeparator()));
+
+                logParameters = !logParameters.trim().isEmpty() ? System.lineSeparator() + logParameters : "";
+                message += logParameters;
+            }
+        } catch (Exception ex) {
+            message = logRecord.getMessage();
+        }
+
+        return message;
+    }
+
+    /**
+     * Checks if TLS debug logging is enabled.
+     *
+     * @return  Returns <b>true</b> if the value of the system property {@value PaxLoggingConstants#LOGGING_CFG_TLS_LOGGING_MODE}
+     *          is not blank and the TLS logging mode is not <b>no_logging</b>.
+     */
+    private boolean isTLSDebugLoggingEnabled() {
+        String property = System.getProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE);
+        return property != null && !property.trim().isEmpty() && !NO_LOGGING_MODE.equals(property);
+    }
+
+    /**
+     * Checks if the TLS log parameter is a hex dump message.
+     *
+     * @param message The TLS log parameter.
+     * @return  If the parameter starts with <b>0000:</b> returns true. Otherwise, returns false.
+     */
+    private boolean isHexDumpMessage(String message) {
+        return message.startsWith(HEX_DUMP_OFFSET, 2);
+    }
 }

--- a/pax-logging-api/src/test/java/org/ops4j/pax/logging/internal/JdkHandlerTest.java
+++ b/pax-logging-api/src/test/java/org/ops4j/pax/logging/internal/JdkHandlerTest.java
@@ -24,6 +24,7 @@ import java.util.logging.LogRecord;
 
 import org.junit.Test;
 import org.ops4j.pax.logging.PaxLogger;
+import org.ops4j.pax.logging.PaxLoggingConstants;
 import org.ops4j.pax.logging.PaxLoggingManager;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Version;
@@ -31,15 +32,18 @@ import org.osgi.framework.wiring.BundleRevision;
 
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 /**
  * @author Chris Dolan
  * @since 6/10/11 10:38 AM
  */
 public class JdkHandlerTest {
+
+    private static final String TLS_LOGGING_MODE_PROPERTY = "com.seeburger.tlsdebug.logmode";
+    private static final String NO_LOGGING_MODE = "no_logging";
+    private static final String DEBUG_LOGGING_MODE = "debug_logging";
+    private static final String NO_HEX_DUMPS_LOGGING_MODE = "no_hex_dumps_logging";
 
     @Test
     public void test() {
@@ -49,6 +53,13 @@ public class JdkHandlerTest {
 
         PaxLoggingManager logManager = mock(PaxLoggingManager.class);
         when(logManager.getLogger(null, "java.util.logging.Logger")).thenReturn(logger);
+        when(logManager.getLogger("javax.net.ssl", "java.util.logging.Logger")).thenReturn(logger);
+        String parameter = "test";
+        String hexDump = "  0000: 16 03 03 00 F1 01 00 00   ED 03 03 60 CB 54 00 5E  ...........`.T.^";
+
+        // TLS log record parameters
+        Object[] parameters = new Object[]{parameter, null, hexDump};
+        String lineSeparator = System.lineSeparator();
 
         JdkHandler handler = new JdkHandler(logManager);
         try {
@@ -63,6 +74,20 @@ public class JdkHandlerTest {
             handler.publish(mkRecord(Level.OFF, "off", null));
             handler.publish(mkRecord(Level.SEVERE, "s", new Throwable()));
 
+            System.setProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE, NO_LOGGING_MODE);
+            handler.publish(mkTLSLogRecord(Level.FINE, "Skip TLS Debug log", null, null));
+
+            System.setProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE, "");
+            handler.publish(mkTLSLogRecord(Level.FINE, "Skip TLS Debug log 1", null, null));
+
+            System.clearProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE);
+            handler.publish(mkTLSLogRecord(Level.FINE, "Skip TLS Debug log 2", null, null));
+
+            System.setProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE, NO_HEX_DUMPS_LOGGING_MODE);
+            handler.publish(mkTLSLogRecord(Level.FINE, "TLS Debug", null, parameters));
+
+            System.setProperty(PaxLoggingConstants.LOGGING_CFG_TLS_LOGGING_MODE, DEBUG_LOGGING_MODE);
+            handler.publish(mkTLSLogRecord(Level.FINE, "TLS Debug", null, parameters));
             handler.flush(); // no-op
         } finally {
             handler.close();
@@ -78,12 +103,29 @@ public class JdkHandlerTest {
         verify(logger).error("s");
         verify(logger).error("off");
         verify(logger).error(eq("s"), isA(Throwable.class));
+        verify(logger, never()).debug("Skip TLS Debug log");
+        verify(logger, never()).debug("Skip TLS Debug log 1");
+        verify(logger, never()).debug("Skip TLS Debug log 2");
+        verify(logger).debug("TLS Debug" + lineSeparator + parameter);
+        verify(logger).debug("TLS Debug" + lineSeparator + parameter + lineSeparator + hexDump);
     }
 
     private LogRecord mkRecord(Level lvl, String msg, Throwable t) {
         LogRecord record = new LogRecord(lvl, msg);
         if (t != null)
             record.setThrown(t);
+        return record;
+    }
+
+    private LogRecord mkTLSLogRecord(Level lvl, String msg, Throwable t, Object[] params){
+        LogRecord record = new LogRecord(lvl, msg);
+        record.setLoggerName("javax.net.ssl");
+        if (t != null)
+            record.setThrown(t);
+
+        if (params != null)
+            record.setParameters(params);
+
         return record;
     }
 

--- a/pax-logging-api/src/test/java/org/ops4j/pax/logging/internal/JdkHandlerTest.java
+++ b/pax-logging-api/src/test/java/org/ops4j/pax/logging/internal/JdkHandlerTest.java
@@ -40,7 +40,6 @@ import static org.mockito.Mockito.*;
  */
 public class JdkHandlerTest {
 
-    private static final String TLS_LOGGING_MODE_PROPERTY = "com.seeburger.tlsdebug.logmode";
     private static final String NO_LOGGING_MODE = "no_logging";
     private static final String DEBUG_LOGGING_MODE = "debug_logging";
     private static final String NO_HEX_DUMPS_LOGGING_MODE = "no_hex_dumps_logging";


### PR DESCRIPTION
Hi,
	
The new JSSE version has been backported to OpenJDK (JDK-8248721) to support TLSv1.3. The logic of TLS debug traces has been changed. The new TLS debug logger uses a configured JUL logger when you define the system property "javax.net.debug" as empty. The TLS JUL records have additional log parameters that contain hex dumps, handshake messages etc. They are without format parameters in the log message. That's why, they aren't parsed and included in the logs by the JdkHandler. They should be appended to the end of the log message in order to prevent loss of useful information.

In addition, the new TLS debug logger does not support the configuration options. As a result, all TLS debug records are logged. In order to filter the TLS debug records, I define a new system variable "org.ops4j.pax.logging.tlsdebug.loggingMode". This variable keeps the logging mode of the TLS logger. The JdkHandler filters log records according to the value of the new system property. Three logging modes are currently defined:
     - no_logging:  No TLS messages are logged.
     - no_hex_dumps_logging: All messages except hex dumps are logged.
     - debug_logging: All TLS messages are logged.
