### PR TITLE
Update log4j2 to 2.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,12 +170,12 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.12.1</version>
+        <version>2.12.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.12.1</version>
+        <version>2.12.2</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Log4j 2.12.2 fixes CVE-2021-45046.
Log4j advices users requiring Java 7 to upgrade to release 2.12.2