### PR TITLE
Pax logging 1.11.x with logback 1.2.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <version.org.apache.tomcat.juli>9.0.43</version.org.apache.tomcat.juli>
         <version.org.apache.xbean>4.18</version.org.apache.xbean>
         <version.biz.aQute.bnd>5.2.0</version.biz.aQute.bnd>
-        <version.ch.qos.logback>1.2.3</version.ch.qos.logback>
+        <version.ch.qos.logback>1.2.9</version.ch.qos.logback>
         <version.ch.qos.logback.contrib>0.1.5</version.ch.qos.logback.contrib>
         <version.com.fasterxml.jackson>2.10.0</version.com.fasterxml.jackson>
         <version.com.h2database>1.4.200</version.com.h2database>


### PR DESCRIPTION
Hello,
I create this PR to include logback 1.2.9 

This version fix the [CVE-2021-42550](https://cve.report/CVE-2021-42550) (aka [LOGBACK-1591](https://jira.qos.ch/browse/LOGBACK-1591))

I know it is NOT the same security level as log4Shell, but i think this should be included too.
