### PR TITLE
Fix parent `relativePath` error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <groupId>org.ops4j</groupId>
         <artifactId>master</artifactId>
         <version>4.3.0</version>
+        <relativePath/>
     </parent>
 
     <groupId>org.ops4j.pax</groupId>


### PR DESCRIPTION
IntelliJ IDEA shows an error for the org.ops4j:master parent because it cannot be found.

See the Maven XSD: https://maven.apache.org/maven-v4_0_0.xsd

> The relative path of the parent `pom.xml` file within the check out.
> If not specified, it defaults to `../pom.xml`.
> Maven looks for the parent POM first in this location on
> the filesystem, then the local repository, and lastly in the remote repo.
> `relativePath` allows you to select a different location,
> for example when your structure is flat, or deeper without an intermediate parent POM.
> However, the group ID, artifact ID and version are still required,
> and must match the file in the location given or it will revert to the repository for the POM.
> This feature is only for enhancing the development in a local checkout of that project.
> Set the value to an empty string in case you want to disable the feature and always resolve
> the parent POM from the repositories.